### PR TITLE
fix performance regression before hitting toplevel

### DIFF
--- a/test/TestPackage/Manifest.toml
+++ b/test/TestPackage/Manifest.toml
@@ -1,0 +1,27 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "6a8a2a625ab0dea913aba95c11370589e0239ff0"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.6"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Memoization]]
+deps = ["MacroTools"]
+path = "../.."
+uuid = "6fafb56a-5788-4b4e-91ca-c0cea6611c73"
+version = "0.1.10"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/test/TestPackage/Project.toml
+++ b/test/TestPackage/Project.toml
@@ -1,0 +1,7 @@
+name = "TestPackage"
+uuid = "5558094e-8230-4a5f-be5d-17f6d252e568"
+authors = ["marius <mariusmillea@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+Memoization = "6fafb56a-5788-4b4e-91ca-c0cea6611c73"

--- a/test/TestPackage/src/TestPackage.jl
+++ b/test/TestPackage/src/TestPackage.jl
@@ -1,0 +1,5 @@
+module TestPackage
+using Memoization
+@memoize foo(x) = x
+foo(1)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,4 +110,8 @@ n=0; @test (uarg(Float64)==Float64 && n==0)
 @generated gen2() = gen1(1)
 @test gen2() == 1
 
+# works when called during precompilation of a package
+@test read(`$(Base.julia_cmd()[1]) --project=$(joinpath(@__DIR__,"TestPackage")) -e "using TestPackage; print(TestPackage.foo(2))"`,String) == "2"
+
+
 end


### PR DESCRIPTION
Fixes the MWE in https://github.com/JuliaGPU/CUDA.jl/issues/984

For certain cases, the thing I was doing before caused an `eval` to be executed for every memoized call until top-level got hit (the MWE is a single `main()` call so top-level was never hit). 