### PR TITLE
better/simpler rework of the get_cache internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.com/marius311/Memoization.jl.svg?branch=master)](https://travis-ci.com/marius311/Memoization.jl)
 
-Easily and efficiently memoize any function in Julia. 
+Easily and efficiently memoize any function, closure, or callable object in Julia.
 
 ## Usage
 
@@ -27,7 +27,7 @@ julia> f(2)
 
 * Your function remains inferrable.
 
-* Multiple memoized methods for the same function can be defined across different modules (no warnings are generated).
+* Multiple memoized methods for the same function can be defined across different modules.
 
 * You can choose the cache type, e.g.,
 
@@ -45,7 +45,7 @@ julia> f(2)
 
 * You can also clear all caches for all functions with `Memoization.empty_all_caches!()`.
 
-* You are free to memoize some methods of a function but not others, e.g.:
+* You can memoize some methods of a function but not others, e.g.:
 
     ```julia
     julia> @memoize f(x) = (println("Computed $x"); x)

--- a/src/Memoization.jl
+++ b/src/Memoization.jl
@@ -112,7 +112,7 @@ macro memoize(ex1, ex2=nothing)
             # @generated function which directly returns the cache,
             # this will cause the cache lookup to be done at compile
             # time
-            @eval @generated function Memoization.get_cache(_, f::typeof($(Expr(:$,:func))))
+            @eval @generated function $Memoization.get_cache(_, f::typeof($(Expr(:$,:func))))
                 $_get!($cache_constructor, $caches, f.instance)
             end
             # since here we know this is a top-level function

--- a/src/Memoization.jl
+++ b/src/Memoization.jl
@@ -12,47 +12,20 @@ const caches = IdDict()
 const cache_constructor_exprs = IdDict()
 
 
-# Only top-level functions are memoized "statically", meaning that
-# get_cache(_,foo) for a top-level function, foo, does *not* result in
-# looking up Memoization.caches[foo] at run-time; the lookup is moved
-# to compile-time via the generated function trickery below. For
-# memoized inner functions, closures, or callables, the lookup is
-# "dynamic" i.e. done at run-time. Technically non-closure inner
-# functions could also be static except for
-# https://github.com/JuliaLang/julia/issues/40576. The following is
-# kind of a kludgy way to tell if we can do the static memoization
-# given the above issue.
-function statically_memoizable(::Type{F}) where {F}
-    try
-        F.instance
-        true
-    catch
-        false
-    end
-end
+# "Statically" memoizable functions are those where we can move the
+# `get_cache` lookup below to compile time, as opposed to having to
+# "dynamically" search the `caches` for the right cache at run-time.
+# Right now, this includes just top-level functions, but in theory
+# could maybe include non-closure inner functions in the future too.
+statically_memoizable(::Type{F}) where {F} = isdefined(F, :instance)
 
+# Lookup `func` in `caches`, and create its cache if its not there.
+# Note: for statically memoizable functions, the macro below will also
+# creates a @generated method for this function specific to each
+# statically memoizable function, such that the lookup becomes static.
+# The following definition is the dynamic fallback:
+get_cache(default, func) = _get!(default, caches, func)
 
-# Look up the cache for a given memoized function. 
-# For statically memoizable functions, if we're not currently
-# precompiling and not in a pure context (in which case the @eval
-# below is disallowed) then in addition to dynamically looking up the
-# right cache, we also define a specialized `get_cache` which makes
-# every subsequent lookup static. For callables and closures, every
-# lookup has to be dynamic. 
-@generated function get_cache(default::Base.Callable, func::F) where {F}
-    if statically_memoizable(F) && ccall(:jl_generating_output,Cint,()) == 0
-        quote
-            if ccall(:jl_is_in_pure_context, Cint, ()) == 0
-                @eval @generated get_cache(::Base.Callable, ::$F) = caches[$(F.instance)]
-            end
-            _get!(default, $caches, func)
-        end
-    else
-        quote
-            _get!(default, $caches, func)
-        end
-    end
-end
 
 """
     empty_cache!(arg)
@@ -124,9 +97,7 @@ macro memoize(ex1, ex2=nothing)
         $T = $(Core.Compiler.return_type)($getter, $Tuple{})
         $_get!($getter, $get_cache($cache_constructor, $cacheid_get), (($(arg_signature...),),(;$(kwarg_signature...),))) :: $T
     end
-    
 
-    canary = gensym("canary")
     quote
         func = Core.@__doc__ $(esc(combinedef(sdef)))
         begin
@@ -136,10 +107,18 @@ macro memoize(ex1, ex2=nothing)
                 error("$func is already memoized with $cache_constructor_expr′")
             end
         end
-        # empty cache, but only if this is a top-level function definition
-        # see also: https://discourse.julialang.org/t/is-there-a-way-to-determine-whether-code-is-toplevel
-        $(esc(canary)) = true
-        if isdefined($__module__, $(QuoteNode(canary)))
+        if statically_memoizable(typeof(func))
+            # define a get_cache specific to `func`. by using a
+            # @generated function which directly returns the cache,
+            # this will cause the cache lookup to be done at compile
+            # time
+            @eval @generated function Memoization.get_cache(_, f::typeof($(Expr(:$,:func))))
+                $_get!($cache_constructor, $caches, f.instance)
+            end
+            # since here we know this is a top-level function
+            # definition, we also need to clear the cache (if it
+            # exists) as existing memoized results may have been
+            # invalidated by the new definition
             $empty_cache!($(esc(cacheid_empty)))
         end
         func

--- a/test/TestPackage/Manifest.toml
+++ b/test/TestPackage/Manifest.toml
@@ -1,0 +1,27 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "6a8a2a625ab0dea913aba95c11370589e0239ff0"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.6"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Memoization]]
+deps = ["MacroTools"]
+path = "../.."
+uuid = "6fafb56a-5788-4b4e-91ca-c0cea6611c73"
+version = "0.1.10"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/test/TestPackage/Project.toml
+++ b/test/TestPackage/Project.toml
@@ -1,0 +1,7 @@
+name = "TestPackage"
+uuid = "5558094e-8230-4a5f-be5d-17f6d252e568"
+authors = ["marius <mariusmillea@gmail.com>"]
+version = "0.1.0"
+
+[deps]
+Memoization = "6fafb56a-5788-4b4e-91ca-c0cea6611c73"

--- a/test/TestPackage/src/TestPackage.jl
+++ b/test/TestPackage/src/TestPackage.jl
@@ -1,5 +1,5 @@
 module TestPackage
-using Memoization
+using Memoization: @memoize
 @memoize foo(x) = x
 foo(1)
 end

--- a/test/TestPackage/src/TestPackage.jl
+++ b/test/TestPackage/src/TestPackage.jl
@@ -1,0 +1,5 @@
+module TestPackage
+using Memoization
+@memoize foo(x) = x
+foo(1)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,4 +110,7 @@ n=0; @test (uarg(Float64)==Float64 && n==0)
 @generated gen2() = gen1(1)
 @test gen2() == 1
 
+# works when called during precompilation of a package
+@test read(`$(Base.julia_cmd()[1]) --project=$(joinpath(@__DIR__,"TestPackage")) -e "using TestPackage; print(TestPackage.foo(2))"`,String) == "2"
+
 end


### PR DESCRIPTION
Vastly simplifies how the get_cache machinery works, and removes some pretty borderline stuff we were doing before. 

Basically, now, for top-level functions, at the time of the memoized definition, we defined a specialized get_cache which makes the lookup static. For everything else, we fall back to the generic (and dynamic) lookup. 

Closes https://github.com/marius311/Memoization.jl/pull/16