### PR TITLE
remove empty namedtuple from key when no kwargs

### DIFF
--- a/src/Memoization.jl
+++ b/src/Memoization.jl
@@ -91,11 +91,20 @@ macro memoize(ex1, ex2=nothing)
         cacheid_get = cacheid_empty = sdef[:name]
     end
     
+    sdef[:body] = if isempty(kwarg_signature)
     # the body of the function definition is replaced with this:
-    sdef[:body] = quote
-        ($getter)() = $(sdef[:body])
-        $T = $(Core.Compiler.return_type)($getter, $Tuple{})
-        $_get!($getter, $get_cache($cache_constructor, $cacheid_get), (($(arg_signature...),),(;$(kwarg_signature...),))) :: $T
+        quote
+            ($getter)() = $(sdef[:body])
+            $T = $(Core.Compiler.return_type)($getter, $Tuple{})
+            $_get!($getter, $get_cache($cache_constructor, $cacheid_get), $(arg_signature...)) :: $T
+        end
+    else
+        quote
+            ($getter)() = $(sdef[:body])
+            $T = $(Core.Compiler.return_type)($getter, $Tuple{})
+            $_get!($getter, $get_cache($cache_constructor, $cacheid_get), (($(arg_signature...),),(;$(kwarg_signature...),))) :: $T
+        end
+
     end
 
     quote


### PR DESCRIPTION
I was getting an error when I was trying to do something like below, where I want to constrain the key and value types (as well as put in a key-value pair on construction).

```julia
using Memoization

foo(x) = x
function bar(::T) where {T<:Integer}
  @memoize Dict{UInt64,T}(UInt64(0)=>T(0)) function baz(x); return foo(x); end
  return baz
end

qux = bar(1)
qux(1)
```

The error is:

```julia
ERROR: MethodError: Cannot `convert` an object of type Tuple{Tuple{Int64}, NamedTuple{(), Tuple{}}} to an object of type UInt64
Closest candidates are:
  convert(::Type{T}, ::Ptr) where T<:Integer at pointer.jl:23
  convert(::Type{T}, ::T) where T<:Number at number.jl:6
  convert(::Type{T}, ::Number) where T<:Number at number.jl:7
  ...
Stacktrace:
 [1] get!(default::Function, h::Dict{UInt64, Int64}, key0::Tuple{Tuple{Int64}, NamedTuple{(), Tuple{}}})
   @ Base ./dict.jl:452
 [2] _get!(::Function, ::Vararg{Any, N} where N)
   @ Memoization ~/.julia/dev/Memoization/src/Memoization.jl:131
 [3] (::var"#baz#3"{Int64})(x::Int64)
   @ Main ~/.julia/dev/Memoization/src/Memoization.jl:98
 [4] top-level scope
   @ REPL[5]:1
```

This appears to be because there is a `NamedTuple` in the key type to handle kwargs. This PR fixes this by findout out if the variable `kwarg_signature` signature is empty in an if statement and then removing that from the quoted expression. There may be a more elegant way of doing this - please advise.

With the fix:

```julia
julia> using Memoization
[ Info: Precompiling Memoization [6fafb56a-5788-4b4e-91ca-c0cea6611c73]

julia> foo(x) = x
foo (generic function with 1 method)

julia> function bar(::T) where {T<:Integer}
         @memoize Dict{UInt64,T}(UInt64(0)=>T(0)) function baz(x); return foo(x); end
         return baz
       end
bar (generic function with 1 method)

julia> qux = bar(1)
(::var"#baz#3"{Int64}) (generic function with 1 method)

julia> qux(1)
1

julia> Memoization.caches
IdDict{Any, Any} with 1 entry:
  baz => Dict{UInt64, Int64}(0x0000000000000000=>0, 0x0000000000000001=>1)
```


